### PR TITLE
- Fix crash in Raze due to parser not accepting malformed comment.

### DIFF
--- a/maphacks/maphacks.def
+++ b/maphacks/maphacks.def
@@ -1,4 +1,4 @@
-#######SHAREWARE########
+// #######SHAREWARE########
 
 mapinfo {
   mapfile  "$BULLET.MAP"


### PR DESCRIPTION
Reported by @Dzierzan in https://github.com/coelckers/Raze/issues/439.

By standard definition, comments in .DEF files should be passed as C++-style comments. Raze's parser is strict and while this shouldn't have crashed our port, it does address the issue.